### PR TITLE
add redirect http->https option to traefik proxy config

### DIFF
--- a/stack-proxy-global.yml
+++ b/stack-proxy-global.yml
@@ -50,7 +50,9 @@ services:
       - --consul.prefix=traefik
       - --defaultentrypoints=http,https
       - --entryPoints=Name:https Address::443 TLS
-      - --entryPoints=Name:http Address::80
+      - --entryPoints=Name:http Address::80 # don't force HTTPS
+      # - --entryPoints=Name:http Address::80 Redirect.EntryPoint:https  # force HTTPS
+      ## optional LetsEncrypt settings
       # - --acme
       # - --acme.email=${TRAEFIK_ACME_EMAIL}
       #   # TODO: envvar for email and default domain

--- a/stack-proxy.yml
+++ b/stack-proxy.yml
@@ -36,6 +36,10 @@ services:
       - --docker.watch
       - --api
       - --defaultentrypoints=http,https
+      - --entryPoints=Name:https Address::443 TLS
+      - --entryPoints=Name:http Address::80 # don't force HTTPS
+      # - --entryPoints=Name:http Address::80 Redirect.EntryPoint:https  # force HTTPS
+      ## optional LetsEncrypt settings
       # - --acme
       # - --acme.email=${TRAEFIK_ACME_EMAIL}
       #   # TODO: envvar for email and default domain
@@ -43,8 +47,6 @@ services:
       # - --acme.httpchallenge.entrypoint=http
       # - --acme.onhostrule=true
       # - --acme.entrypoint=https
-      # - --entryPoints=Name:https Address::443 TLS
-      # - --entryPoints=Name:http Address::80
       # - --acme.storage=/etc/traefik/acme/acme.json
       # - --acme.acmelogging
       # - --acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
make entryPoints config consistent between proxy and proxy-global