### PR TITLE
Adjust ports to use ingress mode to allow cluster-wide access

### DIFF
--- a/stack-proxy-global.yml
+++ b/stack-proxy-global.yml
@@ -81,11 +81,11 @@ services:
       - target: 80
         published: 80
         protocol: tcp
-        mode: host
+        mode: ingress
       - target: 443
         published: 443
         protocol: tcp
-        mode: host
+        mode: ingress
       - target: 8080
         published: 8080
         protocol: tcp


### PR DESCRIPTION
I just finished working with someone who was struggling getting their app running in their cluster, basing their compose files on what you have here. It worked when it worked on the manager, but they moved the containers to a worker node and it stopped working. Realized it was because the ports were binding using host mode, not on the ingress network.

This fixes that 😄 