### PR TITLE
Traefik v2 certresolver

### DIFF
--- a/stack-proxy.yml
+++ b/stack-proxy.yml
@@ -37,7 +37,7 @@ services:
       - --entryPoints.websecure.address=:443
       - --entrypoints.websecure.http.tls=true
       # - --entrypoints.web.http.redirections.entryPoint.to=websecure # force HTTPS
-      # - --entrypoints.web.http.tls.certresolver=default
+      # - --entrypoints.websecure.http.tls.certresolver=default
       ## optional LetsEncrypt settings
       # - --certificatesResolvers.default.acme.email=${TRAEFIK_ACME_EMAIL}
       # - --certificatesResolvers.default.acme.storage=/etc/traefik/acme/acme.json


### PR DESCRIPTION
Hi,
i've just deployed traefik v2 and used this config as a quick reference.
I think the traefik v2 certresolver config has a typo.
What certresolver should be used needs to be defined on the entrypoint with TLS enabled.
In this case "websecure".