### PR TITLE
New rexray install image to support driver reinstallation and version update

### DIFF
--- a/stack-rexray.yml
+++ b/stack-rexray.yml
@@ -1,9 +1,5 @@
 version: "3.7"
 
-# 2. TODO: would prefer on-failure restart_policy, but need to run this in script to look
-# for if plugin exists first before reinstalling
-# 3. TODO: would prefer this picks a driver version, and support driver updates
-
 x-default-opts: 
   &default-opts
   logging:
@@ -16,18 +12,16 @@ x-default-opts:
 services:
   plugin-rexray:
     <<: *default-opts
-    image: mavenugo/swarm-exec:17.03.0-ce
+    image: kaustavb12/rexray-plugin-installer:2021-04-12
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     secrets:
       - rexray_do_token
-    environment:
-      - REXRAY_DO_TOKEN_FILE=/run/secrets/rexray_do_token
-    command: sh -c "docker plugin install --grant-all-permissions rexray/dobs DOBS_REGION=nyc3 DOBS_TOKEN=$$(cat $$REXRAY_DO_TOKEN_FILE) DOBS_CONVERTUNDERSCORES=true"
+    command: sh -c "./install-plugin.sh --driver dobs --version latest --do-secret rexray_do_token --do-region nyc3 --do-convert-underscore"
     deploy:
       mode: global
       restart_policy:
-        condition: none
+        condition: on-failure
 
 secrets:
   rexray_do_token:

--- a/stack-rexray.yml
+++ b/stack-rexray.yml
@@ -17,7 +17,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     secrets:
       - rexray_do_token
-    command: sh -c "./install-plugin.sh --driver dobs --version latest --do-secret rexray_do_token --do-region nyc3 --do-convert-underscore"
+    command: sh -c "./install-plugin.sh --driver dobs --version 0.11.4 --do-secret rexray_do_token --do-region nyc3 --do-convert-underscore"
     deploy:
       mode: global
       restart_policy:


### PR DESCRIPTION
Implemented the rexray related TODO points mentioned in the stack file:

```
# 2. TODO: would prefer on-failure restart_policy, but need to run this in script to look
# for if plugin exists first before reinstalling
```
Changed restart_policy to on-failure. New script detects if plugin already installed and reinstalls if given version is different from installed version or does nothing if version matches. This behavior can be tweaked using script options.


```
# 3. TODO: would prefer this picks a driver version, and support driver updates
```
Specific driver version given for script to install. Can rerun script providing different version to update driver as required. Can also configure script options to reinstall using the 'latest' tag each time it runs.

Using rexray-plugin-installer project that I created. Below are the links:

GitHub:
https://github.com/kaustavb12/rexray-plugin-installer
Docker Hub:
https://hub.docker.com/r/kaustavb12/rexray-plugin-installer
